### PR TITLE
Argument Parser setup 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ target/
 # Mypy cache
 .mypy_cache/
 outcmaes/
+
+# Parameter datafiles
+params/ready/*
+params/completed/*

--- a/params/params_template.yml
+++ b/params/params_template.yml
@@ -1,0 +1,13 @@
+experiment: 
+  name: "three-sat-usa-qaoa"
+  author: "vivek"
+  tracking-uri: "http://115.146.95.176:5000/"
+  seed: 1032918
+
+build_hamiltonians:
+  params:
+    classical_opt_alg: "{{classical_opt_alg}}"
+    optimisation_opts: "{{optimisation_opts}}"
+    alpha_trial: "{{alpha_trial}}"
+    beta_trial: "{{beta_trial}}"
+    n_rounds: "{{n_rounds}}"

--- a/qaoa_three_sat/instance/three_sat.py
+++ b/qaoa_three_sat/instance/three_sat.py
@@ -176,7 +176,7 @@ class QAOAInstance3SAT:
             raise TypeError("alpha must be a list")
         if len(value) != self.n_rounds:
             raise ValueError(
-                "Insufficient alpha parameters passed. Should be %s - User passed %s"
+                "Incorrect number of alpha parameters passed. Should be %s - User passed %s"
                 % (self.n_rounds, len(value))
             )
         self._alpha = value
@@ -192,7 +192,7 @@ class QAOAInstance3SAT:
             raise TypeError("beta must be a list")
         if len(value) != self.n_rounds:
             raise ValueError(
-                "Insufficient beta parameters passed. Should be %s - User passed %s"
+                "Incorrect number of beta parameters passed. Should be %s - User passed %s"
                 % (self.n_rounds, len(value))
             )
         self._beta = value
@@ -429,7 +429,7 @@ class QAOAInstance3SAT:
                 vars_vec=angles,
                 cost_function=self.cost_function,
                 options=self.optimiser_opts,
-            )        
+            )
 
         else:
             # Raise Error if a valid algorithm not specified

--- a/qaoa_three_sat/optimiser/bfgs.py
+++ b/qaoa_three_sat/optimiser/bfgs.py
@@ -39,8 +39,4 @@ class BFGS:
         vars_vec_0 = self.vars_vec
 
         # Optimise alpha and beta using the cost function <s|H|s>
-        res = minimize(
-            self.cost_function,
-            x0=vars_vec_0,
-            method="BFGS"
-        )
+        res = minimize(self.cost_function, x0=vars_vec_0, method="BFGS")

--- a/qaoa_three_sat/simulation/simulate.py
+++ b/qaoa_three_sat/simulation/simulate.py
@@ -1,9 +1,14 @@
-"""Sample simulation script
+""" Simulation script
+
+
 
 Author: Vivek Katial
 """
 
 from math import pi
+import argparse
+import yaml
+import json
 
 # Import Custom Modules
 from qaoa_three_sat.instance.three_sat import QAOAInstance3SAT
@@ -91,34 +96,29 @@ def simulate_circuit(
 
 if __name__ == "__main__":
 
-    instance_filename = "sample_instance"
-    # Classical Optimisation Parameters
+    # Parsing arguments from CLI
+    parser = argparse.ArgumentParser()
+    # Adding command line argument
+    parser.add_argument("--instance", type=str)
+    parser.add_argument("--params_file", type=str)
+    # Parse your arguments
+    args = parser.parse_args()
+    run_path = "params/ready/" + args.params_file
+    instance_filename = args.instance
 
-    # Nelder-Mead
-    # optimisation_opts = {
-    #     "classical_opt_alg": "nelder-mead",
-    #     "xtol": 0.001,
-    #     "disp": True,
-    #     "adaptive": True,
-    #     "simplex_area_param": 0.1,
-    # }
+    print("\nReading yaml file\n")
+    with open(run_path) as file:
+        params = yaml.load(file, Loader=yaml.FullLoader)
 
-    # CMA-ES
-    optimisation_opts = {
-        "classical_opt_alg": "cma-es",
-    }
+    # Optimisation parameters
+    opt_params = params["classical_optimisation"]
 
-    # BFGS
-    # optimisation_opts = {
-    #     "classical_opt_alg": "bfgs",
-    # }
-
-    # optimisation_opts=None
-    classical_opt_alg = "cma-es" #cma-es, nelder-mead, bfgs
-
-    alpha_trial = [0]
-    beta_trial = [-1]
-    n_rounds = 1
+    # Parse params
+    classical_opt_alg = opt_params["classical_opt_alg"]
+    optimisation_opts = eval(opt_params["optimisation_opts"])
+    alpha_trial = json.loads(opt_params["alpha_trial"])
+    beta_trial = json.loads(opt_params["beta_trial"])
+    n_rounds = int(opt_params["n_rounds"])
     track_optimiser = True
 
     simulate_circuit(

--- a/qaoa_three_sat/simulation/simulate.py
+++ b/qaoa_three_sat/simulation/simulate.py
@@ -99,8 +99,12 @@ if __name__ == "__main__":
     # Parsing arguments from CLI
     parser = argparse.ArgumentParser()
     # Adding command line argument
-    parser.add_argument("--instance", type=str)
-    parser.add_argument("--params_file", type=str)
+    parser.add_argument(
+        "-i", "--instance", type=str, help="Name of the instance file being produced"
+    )
+    parser.add_argument(
+        "-p", "--params_file", type=str, help="Parameter file for QAOA run"
+    )
     # Parse your arguments
     args = parser.parse_args()
     run_path = "params/ready/" + args.params_file


### PR DESCRIPTION
There have been 5 changed files:
- `.gitignore` (Added `params` folders to `.gitignore`)
- `params/params_template.yml` (Added template for running QAOA)
- `qaoa_three_sat/instance/three_sat.py` (Fixing up some error messages)
- `qaoa_three_sat/optimiser/bfgs.py`  (Black formatting)
-  `qaoa_three_sat/simulation/simulate.py`:
    - Added two arguments in a sample simulation script (`-i` or `--instance` for the name of instance file)
    - Second argument is (`-p` or `--params_file` for the QAOA parameterization)

